### PR TITLE
Added SSL Support

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -199,6 +199,21 @@ class Curl
         return $this;
     }
 
+    public function ssl( $verify_peer = TRUE, $verify_host = 2, $path_to_cert = NULL) {
+        if ($verify_peer)
+        {
+            $this->option(CURLOPT_SSL_VERIFYPEER, TRUE);
+            $this->option(CURLOPT_SSL_VERIFYHOST, $verify_host);
+            $this->option(CURLOPT_CAINFO, $path_to_cert);
+        }
+        else
+        {
+            $this->option(CURLOPT_SSL_VERIFYPEER, FALSE);
+        }
+        return $this;
+    }
+
+
     public function options($options = array())
     {
         // Merge options in with the rest - done as array_merge() does not overwrite numeric keys


### PR DESCRIPTION
Simply added a ssl() method that takes the required params to set the curl SSL options. I needed this because I'm developing an api that requires SSL and noticed that this option wasn't already there. Thanks for building this library btw.
