### PR TITLE
FIX: keep the error and error string when a request produces an error

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -298,16 +298,19 @@ class Curl {
 		// Execute the request & and hide all output
 		$this->response = curl_exec($this->session);
 		$this->info = curl_getinfo($this->session);
-
+		
 		// Request failed
 		if ($this->response === FALSE)
 		{
-			$this->error_code = curl_errno($this->session);
-			$this->error_string = curl_error($this->session);
-
+			$errno = curl_errno($this->session);
+			$error = curl_error($this->session);
+			
 			curl_close($this->session);
 			$this->set_defaults();
-
+			
+			$this->error_code = $errno;
+			$this->error_string = $error;
+			
 			return FALSE;
 		}
 


### PR DESCRIPTION
When a request produces an error response in the execute method it saves the error_code and error_string in the current instance but both get overwritten by the set_defaults method. This is a small fix to keep the error_code and error_string.
