### PR TITLE
Made http_header() chainable

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -177,6 +177,7 @@ class Curl {
 	public function http_header($header, $content = NULL)
 	{
 		$this->headers[] = $content ? $header . ': ' . $content : $header;
+		return $this;
 	}
 
 	public function http_method($method)


### PR DESCRIPTION
Added `return $this` to http_header() method so it can be chained
