### PR TITLE
Changing relative cert path to absolute

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -212,8 +212,10 @@ class Curl {
 		{
 			$this->option(CURLOPT_SSL_VERIFYPEER, TRUE);
 			$this->option(CURLOPT_SSL_VERIFYHOST, $verify_host);
-			if(isset($path_to_cert))$path_to_cert = realpath($path_to_cert);
-			$this->option(CURLOPT_CAINFO, $path_to_cert);
+			if (isset($path_to_cert)) {
+				$path_to_cert = realpath($path_to_cert);
+				$this->option(CURLOPT_CAINFO, $path_to_cert);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Fixes an issue with windows/xampp where the relative path to the cert file was not being found by curl.
