### PR TITLE
PUT request parameters needed to be URL-encoded

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -141,7 +141,7 @@ class Curl {
 		$this->options($options);
 
 		$this->http_method('put');
-		$this->option(CURLOPT_POSTFIELDS, $params);
+		$this->option(CURLOPT_POSTFIELDS, http_build_query($params));
 
 		// Override method, I think this overrides $_POST with PUT data but... we'll see eh?
 		$this->option(CURLOPT_HTTPHEADER, array('X-HTTP-Method-Override: PUT'));


### PR DESCRIPTION
I am using your REST Client/Server libraries along with your curl library.
I noticed that when sending a PUT request from client to server, the server would receive the data but it wouldn't be in a proper format such as below.

<pre>
------------------------------22061304c7a1
Content-Disposition: form-data; name="id"
15
</pre>


After messing around I determined it to be the curl library.
I then found this article: http://www.lornajane.net/posts/2009/putting-data-fields-with-php-curl

It states that for PUT via curl you should use:
curl_setopt($ch, CURLOPT_POSTFIELDS,http_build_query($data));

After adding http_build_query I am now able to receive data in a proper array format on the REST server
