### PR TITLE
Allow for an option that does not start with CURLOPT such as CURLINFO_HEADER_OUT

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -238,11 +238,11 @@ class Curl {
 		return $this;
 	}
 
-	public function option($code, $value)
+	public function option($code, $value, $prefix = 'opt')
 	{
 		if (is_string($code) && !is_numeric($code))
 		{
-			$code = constant('CURLOPT_' . strtoupper($code));
+			$code = constant('CURL' . strtoupper($prefix) . '_' . strtoupper($code));
 		}
 
 		$this->options[$code] = $value;
@@ -302,19 +302,19 @@ class Curl {
 		// Execute the request & and hide all output
 		$this->response = curl_exec($this->session);
 		$this->info = curl_getinfo($this->session);
-		
+
 		// Request failed
 		if ($this->response === FALSE)
 		{
 			$errno = curl_errno($this->session);
 			$error = curl_error($this->session);
-			
+
 			curl_close($this->session);
 			$this->set_defaults();
-			
+
 			$this->error_code = $errno;
 			$this->error_string = $error;
-			
+
 			return FALSE;
 		}
 


### PR DESCRIPTION
Really lines 241 & 245 are all that matters, but I have my sublime set to trim spaces off the end of lines, so 305, 311, 314, and 317 got trimmed.
