### PR TITLE
Fixed SSL host verification

### DIFF
--- a/libraries/Curl.php
+++ b/libraries/Curl.php
@@ -146,7 +146,7 @@ class Curl {
 		// Override method, I think this overrides $_POST with PUT data but... we'll see eh?
 		$this->option(CURLOPT_HTTPHEADER, array('X-HTTP-Method-Override: PUT'));
 	}
-	
+
 	public function patch($params = array(), $options = array())
 	{
 		// If its an array (instead of a query string) then format it correctly
@@ -238,6 +238,7 @@ class Curl {
 		else
 		{
 			$this->option(CURLOPT_SSL_VERIFYPEER, FALSE);
+			$this->option(CURLOPT_SSL_VERIFYHOST, $verify_host);
 		}
 		return $this;
 	}


### PR DESCRIPTION
Ran into an issue where CURLOPT_SSL_VERIFYHOST was needed even when CURLOPT_SSL_VERIFYPEER was FALSE. Left the $verify_host variable intact.
